### PR TITLE
Downgrade CMake for bionic

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.16)
+cmake_minimum_required(VERSION 3.10)
 project(kubridge VERSION 1.0 LANGUAGES ASM)
 
 if(NOT CMAKE_BUILD_TYPE)


### PR DESCRIPTION
WSL with ubuntu uses bionic's repository which contains CMake version 3.10

Downgrading has no impact on the output and allows for higher compatibility